### PR TITLE
添加歌词文字颜色选项

### DIFF
--- a/plasmoid/contents/config/main.xml
+++ b/plasmoid/contents/config/main.xml
@@ -21,6 +21,12 @@
         <entry name="showReconnectingText" type="Bool">
             <default>true</default>
         </entry>
+        <entry name="shouldUseDefaultThemeTextColor" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="configuredTextColor" type="Color">
+            <default>#ffffff</default>
+        </entry>
 
     </group>
     <group name="Backend">

--- a/plasmoid/contents/ui/configFrontend.qml
+++ b/plasmoid/contents/ui/configFrontend.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts 1.12
 import org.kde.kirigami as Kirigami
+import org.kde.kquickcontrols as KQuickControls
 
 Kirigami.FormLayout {
     id: page
@@ -11,6 +12,8 @@ Kirigami.FormLayout {
     property alias cfg_configuredFontSize: configuredFontSize.text
     property alias cfg_layoutHeight: layoutHeight.text
     property alias cfg_showReconnectingText: showReconnectingText.checked
+    property alias cfg_shouldUseDefaultThemeTextColor: shouldUseDefaultThemeTextColor.checked
+    property alias cfg_configuredTextColor: configuredTextColor.color
 
     TextField {
         id: characterLimit
@@ -41,6 +44,18 @@ Kirigami.FormLayout {
     CheckBox {
         id: showReconnectingText
         text: i18n("Show [Reconnecting...] text when connection lost")
+    }
+
+    CheckBox {
+        id: shouldUseDefaultThemeTextColor
+        text: i18n("Use theme default text color")
+    }
+
+    KQuickControls.ColorButton {
+        id: configuredTextColor
+        Kirigami.FormData.label: i18n("Custom text color:")
+        enabled: !shouldUseDefaultThemeTextColor.checked
+        showAlphaChannel: false
     }
 
 }

--- a/plasmoid/contents/ui/main.qml
+++ b/plasmoid/contents/ui/main.qml
@@ -124,7 +124,9 @@ PlasmoidItem {
             height: plasmoid.configuration.layoutHeight
             verticalAlignment: Text.AlignVCenter
             font.pixelSize: fontSize
-            color: PlasmaCore.Theme.textColor
+            color: plasmoid.configuration.shouldUseDefaultThemeTextColor
+                 ? PlasmaCore.Theme.textColor
+                 : plasmoid.configuration.configuredTextColor
         }
 
         Plasmoid.contextualActions: [


### PR DESCRIPTION
自 KDE 6.6 开始，不知为何，在开启深色模式主题时，歌词颜色显示为黑色，导致难以阅读。

添加一个选项，允许自定义歌词颜色，从而绕过此问题。

Fix #15 
